### PR TITLE
[DO NOT MERGE] SPIKE: Use Orders v2 for PayPal

### DIFF
--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -237,6 +237,9 @@ final class WooCommerce {
 		$this->define_tables();
 		$this->includes();
 		$this->init_hooks();
+
+		// TODO: Where is the best placing for this?
+		include_once dirname( __FILE__ ) . '/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php';
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -244,6 +244,9 @@ final class WooCommerce {
 
 		// Webhook listener for the simple proxy PoC.
 		include_once dirname( __FILE__ ) . '/gateways/paypal/includes/proxy/class-wc-gateway-paypal-proxy-webhook-handler.php';
+
+		// Proxy for the PayPal API.
+		include_once dirname( __FILE__ ) . '/gateways/paypal/includes/proxy/class-wc-gateway-paypal-proxy.php';
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -239,7 +239,11 @@ final class WooCommerce {
 		$this->init_hooks();
 
 		// TODO: Where is the best placing for this?
+		// Webhook listener for the client.
 		include_once dirname( __FILE__ ) . '/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php';
+
+		// Webhook listener for the simple proxy PoC.
+		include_once dirname( __FILE__ ) . '/gateways/paypal/includes/proxy/class-wc-gateway-paypal-proxy-webhook-handler.php';
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -372,6 +372,9 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 
 		if ( $this->use_orders_v2() ) {
 			$paypal_order = $paypal_request->create_paypal_order( $order );
+			if ( ! $paypal_order ) {
+				throw new Exception( 'PayPal order creation failed' );
+			}
 			$order->update_meta_data( '_paypal_order_id', $paypal_order['id'] );
 			$order->save();
 			$redirect_url = $paypal_order['redirect_url'];
@@ -591,7 +594,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		 */
 		return apply_filters(
 			'woocommerce_paypal_use_orders_v2',
-			'yes' === $paypal_settings['use_orders_v2']
+			isset( $paypal_settings['use_orders_v2'] ) && 'yes' === $paypal_settings['use_orders_v2']
 		);
 	}
 }

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -370,9 +370,18 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		$order          = wc_get_order( $order_id );
 		$paypal_request = new WC_Gateway_Paypal_Request( $this );
 
+		if ( $this->use_orders_v2() ) {
+			$paypal_order = $paypal_request->create_paypal_order( $order );
+			$order->update_meta_data( '_paypal_order_id', $paypal_order['id'] );
+			$order->save();
+			$redirect_url = $paypal_order['redirect_url'];
+		} else {
+			$redirect_url = $paypal_request->get_request_url( $order, $this->testmode );
+		}
+
 		return array(
 			'result'   => 'success',
-			'redirect' => $paypal_request->get_request_url( $order, $this->testmode ),
+			'redirect' => $redirect_url,
 		);
 	}
 
@@ -562,5 +571,27 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		);
 
 		return is_countable( $paypal_orders ) ? 1 === count( $paypal_orders ) : false;
+	}
+
+	/**
+	 * Checks if the gateway should use Orders v2 API.
+	 *
+	 * TODO: We expect this flag to be true if the merchant can be migrated,
+	 * i.e. does not need PayPal API keys, and they have accepted ToS.
+	 *
+	 * @return bool
+	 */
+	protected function use_orders_v2() {
+		$paypal_settings = get_option( 'woocommerce_paypal_settings' );
+
+		/**
+		 * Filters whether the gateway should use Orders v2 API.
+		 *
+		 * @param bool $use_orders_v2 Whether the gateway should use Orders v2 API.
+		 */
+		return apply_filters(
+			'woocommerce_paypal_use_orders_v2',
+			'yes' === $paypal_settings['use_orders_v2']
+		);
 	}
 }

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -16,6 +16,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Gateway_Paypal_Request {
 
+	// TODO: This will be replaced with a WPCOM API endpoint
+	const CREATE_ORDER_API_URL = 'https://api-m.sandbox.paypal.com/v2/checkout/orders';
+
 	/**
 	 * Stores line items to send to PayPal.
 	 *
@@ -86,6 +89,161 @@ class WC_Gateway_Paypal_Request {
 		WC_Gateway_Paypal::log( 'PayPal Request Args for order ' . $order->get_order_number() . ': ' . wc_print_r( array_merge( $paypal_args, array_intersect_key( $mask, $paypal_args ) ), true ) );
 
 		return $this->endpoint . http_build_query( $paypal_args, '', '&' );
+	}
+
+	// TODO: This will be replaced with the logic for getting the wpcom access token
+	private function get_paypal_access_token() {
+		$paypal_client_id = $this->gateway->get_option( 'PAYPAL_CLIENT_ID' );
+		$paypal_client_secret = $this->gateway->get_option( 'PAYPAL_CLIENT_SECRET' );
+
+		if ( ! $paypal_client_id || ! $paypal_client_secret ) {
+			error_log( 'PayPal client ID or secret not found. Cannot get access token.' );
+			return null;
+		}
+
+		$args = [
+			'method'    => 'POST',
+			'headers'   => [
+				'Content-Type'  => 'application/x-www-form-urlencoded',
+				'Authorization' => 'Basic ' . base64_encode( $paypal_client_id . ':' . $paypal_client_secret ),
+			],
+			'body'      => 'grant_type=client_credentials',
+			'timeout'   => 45, // TODO
+			'sslverify' => false, // TODO
+		];
+		error_log( 'PayPal access token request: ' . print_r( $args, true ) );
+
+		$response = wp_remote_post( 'https://api-m.sandbox.paypal.com/v1/oauth2/token', $args);
+		if ( is_wp_error( $response ) ) {
+			error_log( 'WordPress HTTP Error (Access Token): ' . $response->get_error_message() );
+			return null;
+		}
+
+    	$http_code = wp_remote_retrieve_response_code( $response );
+    	$body = wp_remote_retrieve_body( $response );
+    	$data = json_decode( $body, true );
+
+    	// Check if the request was successful (HTTP 200 OK) and access token exists
+		if ( $http_code === 200 && isset( $data['access_token'] ) ) {
+			error_log( 'PayPal access token request successful.' );
+			return $data['access_token'];
+		} else {
+			error_log( 'Failed to get PayPal access token. HTTP Code: ' . $http_code . ' Response: ' . $body );
+			return null;
+		}
+	}
+
+	public function create_paypal_order( $order ) {
+		$accessToken = $this->get_paypal_access_token();
+		if ( ! $accessToken ) {
+			error_log( 'Could not obtain PayPal access token. Cannot create order.' );
+			return null;
+		}
+
+		$order_details = [
+    		'intent' => 'CAPTURE', // Or 'AUTHORIZE' (TODO: Check if 'capture later' is supported currently)
+			'purchase_units' => [
+				[
+					'custom_id' => $order->get_id(), // TODO: This can hold a string of 255 chars
+					'amount' => [
+						'currency_code' => get_woocommerce_currency(),
+						'value' => $order->get_total(),
+					],
+					'description' => get_bloginfo( 'name' ), // TODO
+				],
+			],
+			'application_context' => [
+				'return_url' => esc_url_raw( add_query_arg( 'utm_nooverride', '1', $this->gateway->get_return_url( $order ) ) ), // Customer redirected here on approval
+				'cancel_url' => esc_url_raw( $order->get_cancel_order_url_raw() ),  // Customer redirected here on cancellation
+				//'locale' => get_locale(), // TODO: PayPal has its own locale format, will need conversion
+			],
+		];
+
+		$args = [
+			'method'    => 'POST',
+			'headers'   => [
+				'Content-Type'  => 'application/json',
+				'Authorization' => 'Bearer ' . $accessToken,
+				'PayPal-Request-Id' => uniqid(), // A unique ID for idempotency (recommended by PayPal)
+			],
+			'body'      => json_encode( $order_details ),
+			'timeout'   => 45, // TODO
+			'sslverify' => false, // TODO
+		];
+
+    	error_log( 'PayPal order creation request: ' . print_r( $args, true ) );
+    	$response = wp_remote_post( CREATE_ORDER_API_URL, $args );
+		if ( is_wp_error( $response ) ) {
+			error_log( 'WordPress HTTP Error (Create Order): ' . $response->get_error_message() );
+			return null;
+		}
+
+		$http_code = wp_remote_retrieve_response_code( $response );
+		$body = wp_remote_retrieve_body( $response );
+		$data = json_decode( $body, true );
+		error_log( 'PayPal order creation response: ' . print_r( $data, true ) );
+
+		// Check if the order creation was successful (HTTP 201 Created)
+		if ( $http_code === 201 && isset( $data['id'] ) && isset( $data['links'] ) ) {
+			// Find the 'approve' link in the response -- this is where we will redirect the customer to
+			$redirect_url = null;
+			foreach ( $data['links'] as $link ) {
+				if ( $link['rel'] === 'approve' && $link['method'] === 'GET' ) {
+					$redirect_url = $link['href'];
+					break;
+				}
+			}
+
+			return [
+				'id' => $data['id'],
+				'redirect_url' => $redirect_url,
+			];
+		} else {
+			error_log( 'Failed to create PayPal order. HTTP Code: ' . $http_code . ' Response: ' . $body );
+			return null;
+		}
+	}
+
+	// TODO: The capture phase will likely live in the wpcom layer
+	public function capture_paypal_order( $order, $capture_url ) {
+		$accessToken = $this->get_paypal_access_token();
+		if ( ! $accessToken ) {
+			error_log( 'Could not obtain PayPal access token. Cannot capture order.' );
+			return null;
+		}
+
+		$paypal_order_id = $order->get_meta( '_paypal_order_id' );
+		if ( ! $paypal_order_id ) {
+			error_log( 'PayPal order ID not found. Cannot capture order.' );
+			return null;
+		}
+
+		$args = [
+			'method'    => 'POST',
+			'headers'   => [
+				'Content-Type'  => 'application/json',
+				'Authorization' => 'Bearer ' . $accessToken,
+			],
+			'body'      => json_encode( [ 'id' => $paypal_order_id ] ),
+		];
+
+		$response = wp_remote_post( $capture_url, $args );
+		if ( is_wp_error( $response ) ) {
+			error_log( 'WordPress HTTP Error (Capture Order): ' . $response->get_error_message() );
+			return null;
+		}
+
+		$http_code = wp_remote_retrieve_response_code( $response );
+		$body = wp_remote_retrieve_body( $response );
+		$data = json_decode( $body, true );
+		error_log( 'PayPal order capture response: ' . print_r( $data, true ) );
+
+		if ( $http_code === 200 && isset( $data['status'] ) && $data['status'] === 'COMPLETED' ) {
+			return true;
+		} else {
+			error_log( 'Failed to capture PayPal order. HTTP Code: ' . $http_code . ' Response: ' . $body );
+			return false;
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -15,10 +15,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Generates requests to send to PayPal.
  */
 class WC_Gateway_Paypal_Request {
-
-	// TODO: This will be replaced with a WPCOM API endpoint
-	const CREATE_ORDER_API_URL = 'https://api-m.sandbox.paypal.com/v2/checkout/orders';
-
 	/**
 	 * Stores line items to send to PayPal.
 	 *
@@ -91,64 +87,19 @@ class WC_Gateway_Paypal_Request {
 		return $this->endpoint . http_build_query( $paypal_args, '', '&' );
 	}
 
-	// TODO: This will be replaced with the logic for getting the wpcom access token
-	private function get_paypal_access_token() {
-		$paypal_client_id = $this->gateway->get_option( 'PAYPAL_CLIENT_ID' );
-		$paypal_client_secret = $this->gateway->get_option( 'PAYPAL_CLIENT_SECRET' );
-
-		if ( ! $paypal_client_id || ! $paypal_client_secret ) {
-			error_log( 'PayPal client ID or secret not found. Cannot get access token.' );
-			return null;
-		}
-
-		$args = [
-			'method'    => 'POST',
-			'headers'   => [
-				'Content-Type'  => 'application/x-www-form-urlencoded',
-				'Authorization' => 'Basic ' . base64_encode( $paypal_client_id . ':' . $paypal_client_secret ),
-			],
-			'body'      => 'grant_type=client_credentials',
-			'timeout'   => 45, // TODO
-			'sslverify' => false, // TODO
-		];
-		error_log( 'PayPal access token request: ' . print_r( $args, true ) );
-
-		$response = wp_remote_post( 'https://api-m.sandbox.paypal.com/v1/oauth2/token', $args);
-		if ( is_wp_error( $response ) ) {
-			error_log( 'WordPress HTTP Error (Access Token): ' . $response->get_error_message() );
-			return null;
-		}
-
-    	$http_code = wp_remote_retrieve_response_code( $response );
-    	$body = wp_remote_retrieve_body( $response );
-    	$data = json_decode( $body, true );
-
-    	// Check if the request was successful (HTTP 200 OK) and access token exists
-		if ( $http_code === 200 && isset( $data['access_token'] ) ) {
-			error_log( 'PayPal access token request successful.' );
-			return $data['access_token'];
-		} else {
-			error_log( 'Failed to get PayPal access token. HTTP Code: ' . $http_code . ' Response: ' . $body );
-			return null;
-		}
-	}
-
 	public function create_paypal_order( $order ) {
-		$accessToken = $this->get_paypal_access_token();
-		if ( ! $accessToken ) {
-			error_log( 'Could not obtain PayPal access token. Cannot create order.' );
-			return null;
-		}
-
 		$order_details = [
-    		'intent' => 'CAPTURE', // Or 'AUTHORIZE' (TODO: Check if 'capture later' is supported currently)
+    		'intent' => 'CAPTURE', // TODO:Or 'AUTHORIZE' for capture-later
 			'purchase_units' => [
+				// TODO: line items
 				[
+					// TODO: Must limit to 255 chars.
 					'custom_id' => wp_json_encode(
 						[
 							'order_id' => $order->get_id(),
 							'order_key' => $order->get_order_key(),
-							'endpoint' => get_site_url( null, '/wp-json/wc-paypal-gateway/v1/webhook' ), // Endpoint to send webhooks to
+							// Endpoint for the proxy to forward webhooks to.
+							'endpoint' => get_site_url( null, '/wp-json/wc-paypal-gateway/v1/webhook' ),
 						]
 					),
 					'amount' => [
@@ -157,7 +108,9 @@ class WC_Gateway_Paypal_Request {
 					],
 					'description' => get_bloginfo( 'name' ), // TODO
 					'payee' => [
-						'email_address' => $this->gateway->get_option( 'payee_email' ), // TODO: For spike only, to test payee
+						// TODO: For spike only, to be able to test a different payee.
+						// This should be $this->gateway->get_option( 'email' ) in the future.
+						'email_address' => get_option( 'wc_paypal_api_payee_email' ),
 					],
 				],
 			],
@@ -168,33 +121,16 @@ class WC_Gateway_Paypal_Request {
 			],
 		];
 
-		$args = [
-			'method'    => 'POST',
-			'headers'   => [
-				'Content-Type'  => 'application/json',
-				'Authorization' => 'Bearer ' . $accessToken,
-				'PayPal-Request-Id' => uniqid(), // A unique ID for idempotency (recommended by PayPal)
-			],
-			'body'      => json_encode( $order_details ),
-			'timeout'   => 45, // TODO
-			'sslverify' => false, // TODO
-		];
+		$request = WP_REST_Request::from_url( get_site_url( null, '/wp-json/wc-paypal-gateway-proxy/v1/create-order' ) );
+		$request->set_method( 'POST' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		// TODO: Authenticate with wpcom.
+		// $request->set_header( 'Authorization', 'Bearer ' . $wpcom_blog_token );
+		$request->set_body( json_encode( $order_details ) );
+		$response = rest_do_request( $request );
 
-    	error_log( 'PayPal order creation request: ' . print_r( $args, true ) );
-
-		$response = wp_remote_post( self::CREATE_ORDER_API_URL, $args );
-		if ( is_wp_error( $response ) ) {
-			error_log( 'WordPress HTTP Error (Create Order): ' . $response->get_error_message() );
-			return null;
-		}
-
-		$http_code = wp_remote_retrieve_response_code( $response );
-		$body = wp_remote_retrieve_body( $response );
-		$data = json_decode( $body, true );
-		error_log( 'PayPal order creation response: ' . print_r( $data, true ) );
-
-		// Check if the order creation was successful (HTTP 201 Created)
-		if ( $http_code === 201 && isset( $data['id'] ) && isset( $data['links'] ) ) {
+		$data = $response->get_data();
+		if ( 200 === $response->get_status() && isset( $data['id'] ) && isset( $data['links'] ) ) {
 			// Find the 'approve' link in the response -- this is where we will redirect the customer to
 			$redirect_url = null;
 			foreach ( $data['links'] as $link ) {
@@ -209,50 +145,34 @@ class WC_Gateway_Paypal_Request {
 				'redirect_url' => $redirect_url,
 			];
 		} else {
-			error_log( 'Failed to create PayPal order. HTTP Code: ' . $http_code . ' Response: ' . $body );
+			error_log( '(Client) PayPal order creation request failed: ' . print_r( $data, true ) );
 			return null;
 		}
 	}
 
-	public function capture_paypal_order( $order, $capture_url ) {
-		$accessToken = $this->get_paypal_access_token();
-		if ( ! $accessToken ) {
-			error_log( 'Could not obtain PayPal access token. Cannot capture order.' );
-			return null;
-		}
-
+	public function capture_payment( $order, $capture_url ) {
 		$paypal_order_id = $order->get_meta( '_paypal_order_id' );
 		if ( ! $paypal_order_id ) {
-			error_log( 'PayPal order ID not found. Cannot capture order.' );
+			error_log( '(Client) PayPal order ID not found. Cannot capture order.' );
 			return null;
 		}
 
-		$args = [
-			'method'    => 'POST',
-			'headers'   => [
-				'Content-Type'  => 'application/json',
-				'Authorization' => 'Bearer ' . $accessToken,
-			],
-			'body'      => json_encode( [ 'id' => $paypal_order_id ] ),
-		];
+		$request = WP_REST_Request::from_url( get_site_url( null, '/wp-json/wc-paypal-gateway-proxy/v1/capture-payment' ) );
+		$request->set_method( 'POST' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		// TODO: Authenticate with wpcom.
+		// $request->set_header( 'Authorization', 'Bearer ' . $wpcom_blog_token );
+		$request->set_body( json_encode( [ 'capture_url' => $capture_url, 'paypal_order_id' => $paypal_order_id ] ) );
+		$response = rest_do_request( $request );
 
-		$response = wp_remote_post( $capture_url, $args );
-		if ( is_wp_error( $response ) ) {
-			error_log( 'WordPress HTTP Error (Capture Order): ' . $response->get_error_message() );
-			return null;
-		}
-
-		$http_code = wp_remote_retrieve_response_code( $response );
-		$body = wp_remote_retrieve_body( $response );
-		$data = json_decode( $body, true );
-		error_log( 'PayPal order capture response: ' . print_r( $data, true ) );
-
-		if ( in_array( $http_code, [ 200, 201 ] ) && isset( $data['status'] ) && $data['status'] === 'COMPLETED' ) {
-			return true;
-		} else {
-			error_log( 'Failed to capture PayPal order. HTTP Code: ' . $http_code . ' Response: ' . $body );
+		if ( 200 !== $response->get_status() ) {
+			error_log( '(Client) PayPal capture payment request failed: ' . print_r( $response->get_data(), true ) );
 			return false;
 		}
+
+		$data = $response->get_data();
+		error_log( '(Client) PayPal capture payment response: ' . print_r( $data, true ) );
+		return true;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -150,6 +150,9 @@ class WC_Gateway_Paypal_Request {
 						'value' => $order->get_total(),
 					],
 					'description' => get_bloginfo( 'name' ), // TODO
+					'payee' => [
+						'email_address' => $this->gateway->get_option( 'payee_email' ), // TODO: For spike only, to test payee
+					],
 				],
 			],
 			'application_context' => [
@@ -172,7 +175,7 @@ class WC_Gateway_Paypal_Request {
 		];
 
     	error_log( 'PayPal order creation request: ' . print_r( $args, true ) );
-    	$response = wp_remote_post( CREATE_ORDER_API_URL, $args );
+		$response = wp_remote_post( self::CREATE_ORDER_API_URL, $args );
 		if ( is_wp_error( $response ) ) {
 			error_log( 'WordPress HTTP Error (Create Order): ' . $response->get_error_message() );
 			return null;
@@ -238,7 +241,7 @@ class WC_Gateway_Paypal_Request {
 		$data = json_decode( $body, true );
 		error_log( 'PayPal order capture response: ' . print_r( $data, true ) );
 
-		if ( $http_code === 200 && isset( $data['status'] ) && $data['status'] === 'COMPLETED' ) {
+		if ( in_array( $http_code, [ 200, 201 ] ) && isset( $data['status'] ) && $data['status'] === 'COMPLETED' ) {
 			return true;
 		} else {
 			error_log( 'Failed to capture PayPal order. HTTP Code: ' . $http_code . ' Response: ' . $body );

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -144,7 +144,13 @@ class WC_Gateway_Paypal_Request {
     		'intent' => 'CAPTURE', // Or 'AUTHORIZE' (TODO: Check if 'capture later' is supported currently)
 			'purchase_units' => [
 				[
-					'custom_id' => $order->get_id(), // TODO: This can hold a string of 255 chars
+					'custom_id' => wp_json_encode(
+						[
+							'order_id' => $order->get_id(),
+							'order_key' => $order->get_order_key(),
+							'endpoint' => get_site_url( null, '/wp-json/wc-paypal-gateway/v1/webhook' ), // Endpoint to send webhooks to
+						]
+					),
 					'amount' => [
 						'currency_code' => get_woocommerce_currency(),
 						'value' => $order->get_total(),
@@ -175,6 +181,7 @@ class WC_Gateway_Paypal_Request {
 		];
 
     	error_log( 'PayPal order creation request: ' . print_r( $args, true ) );
+
 		$response = wp_remote_post( self::CREATE_ORDER_API_URL, $args );
 		if ( is_wp_error( $response ) ) {
 			error_log( 'WordPress HTTP Error (Create Order): ' . $response->get_error_message() );
@@ -207,7 +214,6 @@ class WC_Gateway_Paypal_Request {
 		}
 	}
 
-	// TODO: The capture phase will likely live in the wpcom layer
 	public function capture_paypal_order( $order, $capture_url ) {
 		$accessToken = $this->get_paypal_access_token();
 		if ( ! $accessToken ) {

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -71,6 +71,7 @@ class WC_Gateway_Paypal_Webhook_Handler {
 
                 // TODO: Add order notes
                 break;
+            // TODO: Handle CHECKOUT.ORDER.COMPLETED
             // TODO: Handle failed cases
             default:
                 error_log( 'Unhandled PayPal webhook event: ' . print_r( $data, true ) );

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -1,0 +1,84 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+require_once dirname( __FILE__ ) . '/class-wc-gateway-paypal-request.php';
+
+class WC_Gateway_Paypal_Webhook_Handler {
+    public function __construct() {
+        add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+    }
+
+    public function register_routes() {
+        register_rest_route( 'wc-paypal-gateway/v1', '/webhook', [
+            'methods'             => 'POST',
+            'callback'            => array( $this, 'handle_paypal_webhook' ),
+            'permission_callback' => '__return_true', // TODO: Secure this properly.
+        ] );
+
+        register_rest_route( 'wc-paypal-gateway/v1', '/test-webhook', [
+            'methods'             => 'GET',
+            'callback'            => array( $this, 'test_webhook' ),
+            'permission_callback' => '__return_true', // TODO: Secure this properly.
+        ] );
+    }
+
+    public function test_webhook( WP_REST_Request $request ) {
+        $data = $request->get_json_params();
+        error_log( 'PayPal test webhook received: ' . print_r( $data, true ) );
+        return new WP_REST_Response( 'Test webhook processed', 200 );
+    }
+
+    public function handle_paypal_webhook( WP_REST_Request $request ) {
+        // TODO: Validate the webhook signature
+
+        $data = $request->get_json_params();
+        error_log( 'PayPal webhook received: ' . print_r( $data, true ) );
+
+        // TODO: This will be replaced by events from wpcom.
+        // CHECKOUT.ORDER.APPROVED is likely to be handled by the wpcom layer only.
+        // We likely will only need to handle payment capture events.
+        switch ( $data['event_type'] ) {
+            case 'CHECKOUT.ORDER.APPROVED':
+                $order_id = $data['resource']['purchase_units'][0]['custom_id'];
+                $order = wc_get_order( $order_id );
+                // TODO: How can we verify we are working on the correct order?
+                // Maybe verify the PayPal order ID, ie. $data['resource']['id'] with $order->get_meta( '_paypal_order_id' )?
+
+                if ( $data['resource']['status'] === 'APPROVED' ) {
+                    $capture_url = null;
+                    foreach ( $data['resource']['links'] as $link ) {
+                        if ( $link['rel'] === 'capture' && $link['method'] === 'POST' ) {
+                            $capture_url = $link['href'];
+                            break;
+                        }
+                    }
+
+                    $gateway = WC()->payment_gateways()->payment_gateways()['paypal'];
+                    $paypal_request = new WC_Gateway_Paypal_Request( $gateway );
+                    $result = $paypal_request->capture_paypal_order( $order, $capture_url );
+                    error_log( 'PayPal capture result: ' . print_r( $result, true ) );
+                }
+                break;
+            case 'PAYMENT.CAPTURE.COMPLETED':
+                $order_id = $data['resource']['custom_id'];
+                $order = wc_get_order( $order_id );
+                // TODO: How can we verify we are working on the correct order?
+                // Maybe verify the PayPal order ID, ie. $data['resource']['id'] with $order->get_meta( '_paypal_order_id' )?
+
+                $order->payment_complete();
+
+                // TODO: Add order notes
+                break;
+            // TODO: Handle failed cases
+            default:
+                error_log( 'Unhandled PayPal webhook event: ' . print_r( $data, true ) );
+                break;
+        }
+
+        return new WP_REST_Response( 'Webhook processed', 200 );
+    }
+}
+
+new WC_Gateway_Paypal_Webhook_Handler();

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -34,7 +34,7 @@ class WC_Gateway_Paypal_Webhook_Handler {
         // TODO: Validate the webhook signature
 
         $data = $request->get_json_params();
-        error_log( '(Client) PayPal webhook received: ' . print_r( $data, true ) );
+        error_log( '(Client) Webhook received: ' . print_r( $data, true ) );
 
         switch ( $data['event_type'] ) {
             case 'CHECKOUT.ORDER.APPROVED':
@@ -59,8 +59,7 @@ class WC_Gateway_Paypal_Webhook_Handler {
 
                     $gateway = WC()->payment_gateways()->payment_gateways()['paypal'];
                     $paypal_request = new WC_Gateway_Paypal_Request( $gateway );
-                    $result = $paypal_request->capture_paypal_order( $order, $capture_url );
-                    error_log( 'PayPal capture result: ' . print_r( $result, true ) );
+                    $paypal_request->capture_payment( $order, $capture_url );
                 }
                 break;
             case 'PAYMENT.CAPTURE.COMPLETED':

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -34,17 +34,19 @@ class WC_Gateway_Paypal_Webhook_Handler {
         // TODO: Validate the webhook signature
 
         $data = $request->get_json_params();
-        error_log( 'PayPal webhook received: ' . print_r( $data, true ) );
+        error_log( '(Client) PayPal webhook received: ' . print_r( $data, true ) );
 
-        // TODO: This will be replaced by events from wpcom.
-        // CHECKOUT.ORDER.APPROVED is likely to be handled by the wpcom layer only.
-        // We likely will only need to handle payment capture events.
         switch ( $data['event_type'] ) {
             case 'CHECKOUT.ORDER.APPROVED':
-                $order_id = $data['resource']['purchase_units'][0]['custom_id'];
+                $order_id = $this->get_order_id_from_custom_data( $data['resource']['purchase_units'][0]['custom_id'] );
                 $order = wc_get_order( $order_id );
-                // TODO: How can we verify we are working on the correct order?
-                // Maybe verify the PayPal order ID, ie. $data['resource']['id'] with $order->get_meta( '_paypal_order_id' )?
+                if ( ! $order ) {
+                    error_log( 'Order not found: ' . $order_id );
+                    return new WP_REST_Response( 'Order not found', 404 );
+                }
+
+                // TODO: Maybe verify order key and PayPal order ID, to
+                // ensure this is for the correct order.
 
                 if ( $data['resource']['status'] === 'APPROVED' ) {
                     $capture_url = null;
@@ -62,14 +64,17 @@ class WC_Gateway_Paypal_Webhook_Handler {
                 }
                 break;
             case 'PAYMENT.CAPTURE.COMPLETED':
-                $order_id = $data['resource']['custom_id'];
+                $order_id = $this->get_order_id_from_custom_data( $data['resource']['custom_id'] );
                 $order = wc_get_order( $order_id );
-                // TODO: How can we verify we are working on the correct order?
-                // Maybe verify the PayPal order ID, ie. $data['resource']['id'] with $order->get_meta( '_paypal_order_id' )?
+                if ( ! $order ) {
+                    error_log( 'Order not found: ' . $order_id );
+                    return new WP_REST_Response( 'Order not found', 404 );
+                }
 
+                // TODO: Maybe verify order key and PayPal order ID, to
+                // ensure this is for the correct order.
                 $order->payment_complete();
-
-                // TODO: Add order notes
+                $order->add_order_note( 'PayPal payment captured. ID: ' . $data['resource']['id'] );
                 break;
             // TODO: Handle CHECKOUT.ORDER.COMPLETED
             // TODO: Handle failed cases
@@ -79,6 +84,11 @@ class WC_Gateway_Paypal_Webhook_Handler {
         }
 
         return new WP_REST_Response( 'Webhook processed', 200 );
+    }
+
+    private function get_order_id_from_custom_data( $custom_data ) {
+        $data = json_decode( $custom_data );
+        return $data->order_id ?? null;
     }
 }
 

--- a/plugins/woocommerce/includes/gateways/paypal/includes/proxy/class-wc-gateway-paypal-proxy-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/proxy/class-wc-gateway-paypal-proxy-webhook-handler.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Proof of concept class for proxying PayPal webhooks (simple proxy).
+ *
+ * This will live in WPCOM and will act as a layer between the client and the PayPal API.
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class WC_Gateway_Paypal_Proxy_Webhook_Handler {
+    public function __construct() {
+        add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+    }
+
+    public function register_routes() {
+        register_rest_route( 'wc-paypal-gateway-proxy/v1', '/webhook', [
+            'methods'             => 'POST',
+            'callback'            => array( $this, 'handle_paypal_webhook' ),
+            'permission_callback' => '__return_true', // TODO: Secure this properly.
+        ] );
+
+        register_rest_route( 'wc-paypal-gateway-proxy/v1', '/test-webhook', [
+            'methods'             => 'GET',
+            'callback'            => array( $this, 'test_webhook' ),
+            'permission_callback' => '__return_true', // TODO: Secure this properly.
+        ] );
+    }
+
+    public function test_webhook( WP_REST_Request $request ) {
+        $data = $request->get_json_params();
+        error_log( 'PayPal test webhook received: ' . print_r( $data, true ) );
+        return new WP_REST_Response( 'Test webhook processed', 200 );
+    }
+
+    public function handle_paypal_webhook( WP_REST_Request $request ) {
+        // TODO: Validate the webhook signature
+        // https://developer.paypal.com/api/rest/webhooks/rest/#link-messageverification
+
+        $data = $request->get_json_params();
+        error_log( '(Proxy) PayPal webhook received: ' . print_r( $data, true ) );
+
+        switch ( $data['event_type'] ) {
+            case 'CHECKOUT.ORDER.APPROVED':
+                $custom_client_data = $data['resource']['purchase_units'][0]['custom_id'];
+                $client_endpoint = $this->get_client_webhook_endpoint( $custom_client_data );
+
+                if ( ! $client_endpoint ) {
+                    error_log( 'No client webhook endpoint found' );
+                    return new WP_REST_Response( 'No client webhook endpoint found', 400 );
+                }
+
+                $response = $this->forward_webhook_to_client( $client_endpoint, $data );
+                if ( is_wp_error( $response ) || $response->get_status() !== 200 ) {
+                    error_log( 'Webhook forwarding failed: ' . $response->get_error_message() );
+                    return new WP_REST_Response( 'Webhook forwarding failed', 500 );
+                }
+                break;
+            case 'PAYMENT.CAPTURE.COMPLETED':
+                $custom_client_data = $data['resource']['custom_id'];
+                $client_endpoint = $this->get_client_webhook_endpoint( $custom_client_data );
+
+                if ( ! $client_endpoint ) {
+                    error_log( 'No client webhook endpoint found' );
+                    return new WP_REST_Response( 'No client webhook endpoint found', 400 );
+                }
+
+                $response = $this->forward_webhook_to_client( $client_endpoint, $data );
+                if ( is_wp_error( $response ) || $response->get_status() !== 200 ) {
+                    error_log( 'Webhook forwarding failed: ' . $response->get_error_message() );
+                    return new WP_REST_Response( 'Webhook forwarding failed', 500 );
+                }
+
+                break;
+            default:
+                error_log( 'Unhandled PayPal webhook event: ' . print_r( $data, true ) );
+                break;
+        }
+
+        return new WP_REST_Response( 'Webhook processed', 200 );
+    }
+
+    private function get_client_webhook_endpoint( $custom_client_data ) {
+        $data = json_decode( $custom_client_data );
+        $endpoint = $data->endpoint ?? null;
+
+        if ( ! $endpoint || ! wp_http_validate_url( $endpoint ) ) {
+            error_log( 'Invalid client webhook endpoint: ' . $endpoint );
+            return null;
+        }
+
+        return $endpoint;
+    }
+
+    private function forward_webhook_to_client( $client_endpoint, $data ) {
+        error_log( 'Forwarding webhook to client: ' . $client_endpoint );
+
+        // Forward the webhook to the client.
+        $request = WP_REST_Request::from_url( $client_endpoint );
+        $request->set_method( 'POST' );
+        $request->set_header( 'Content-Type', 'application/json' );
+        $request->set_body( json_encode( $data ) );
+        return rest_do_request( $request );
+    }
+}
+
+new WC_Gateway_Paypal_Proxy_Webhook_Handler();

--- a/plugins/woocommerce/includes/gateways/paypal/includes/proxy/class-wc-gateway-paypal-proxy.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/proxy/class-wc-gateway-paypal-proxy.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Proof of concept class for proxying requests to the PayPal API.
+ *
+ * This will live in WPCOM and will act as a layer between the client and the PayPal API.
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class WC_Gateway_Paypal_Proxy {
+    public function __construct() {
+        add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+    }
+
+    public function register_routes() {
+        register_rest_route( 'wc-paypal-gateway-proxy/v1', '/create-order', [
+            'methods'             => 'POST',
+            'callback'            => array( $this, 'create_paypal_order' ),
+            'permission_callback' => '__return_true', // TODO: Secure this properly.
+        ] );
+
+        register_rest_route( 'wc-paypal-gateway-proxy/v1', '/capture-payment', [
+            'methods'             => 'POST',
+            'callback'            => array( $this, 'capture_payment' ),
+            'permission_callback' => '__return_true', // TODO: Secure this properly.
+        ] );
+
+        register_rest_route( 'wc-paypal-gateway-proxy/v1', '/test-request', [
+            'methods'             => 'GET',
+            'callback'            => array( $this, 'test_request' ),
+            'permission_callback' => '__return_true', // TODO: Secure this properly.
+        ] );
+    }
+
+    public function test_request( WP_REST_Request $request ) {
+        $data = $request->get_json_params();
+        error_log( '(Proxy) PayPal test request received: ' . print_r( $data, true ) );
+        return new WP_REST_Response( 'Test request processed', 200 );
+    }
+
+    public function create_paypal_order( WP_REST_Request $request ) {
+        $request_data = $request->get_json_params();
+        error_log( '(Proxy) PayPal create order request received: ' . print_r( $request_data, true ) );
+
+        $access_token = $this->get_paypal_access_token();
+        if ( ! $access_token ) {
+            error_log( '(Proxy) Failed to get PayPal access token.' );
+            return new WP_REST_Response(
+                [ 'error' => 'Failed to get PayPal access token.' ],
+                500
+            );
+        }
+
+        $args = [
+			'method'    => 'POST',
+			'headers'   => [
+				'Content-Type'  => 'application/json',
+				'Authorization' => 'Bearer ' . $access_token,
+				'PayPal-Request-Id' => uniqid(), // A unique ID for idempotency (recommended by PayPal)
+			],
+			'body'      => json_encode( $request_data ),
+			'timeout'   => 45, // TODO
+			'sslverify' => false, // TODO
+		];
+
+    	error_log( '(Proxy) PayPal order creation request: ' . print_r( $args, true ) );
+
+		$response = wp_remote_post( 'https://api-m.sandbox.paypal.com/v2/checkout/orders', $args );
+		$http_code = wp_remote_retrieve_response_code( $response );
+		$body = wp_remote_retrieve_body( $response );
+		$response_data = json_decode( $body, true );
+		error_log( '(Proxy) PayPal order creation response: ' . print_r( $response_data, true ) );
+
+		if ( in_array( $http_code, [ 200, 201 ], true ) ) {
+			return new WP_REST_Response(
+				$response_data,
+                200
+            );
+        } else {
+            error_log( '(Proxy) Create order request failed: ' . print_r( $response_data, true ) );
+            return new WP_REST_Response(
+                [ 'error' => 'Order creation failed.', 'data' => $response_data ],
+                500
+            );
+        }
+    }
+
+    public function capture_payment( WP_REST_Request $request ) {
+        $request_data = $request->get_json_params();
+        error_log( '(Proxy) PayPal capture payment request received: ' . print_r( $request_data, true ) );
+
+        $access_token = $this->get_paypal_access_token();
+        if ( ! $access_token ) {
+            error_log( '(Proxy) Failed to get PayPal access token. Cannot capture payment.' );
+            return new WP_REST_Response(
+                [ 'status' => 'error', 'message' => 'Failed to get PayPal access token.' ],
+                500
+            );
+        }
+
+        if ( empty( $request_data['capture_url'] ) || empty( $request_data['paypal_order_id'] ) ) {
+            error_log( '(Proxy) Capture URL or PayPal order ID missing. Cannot capture payment.' );
+            return new WP_REST_Response(
+                [ 'status' => 'error', 'message' => 'Capture URL or PayPal order ID missing.' ],
+                400
+            );
+        }
+
+        $capture_url = $request_data['capture_url'];
+        $paypal_order_id = $request_data['paypal_order_id'];
+
+        $args = [
+			'method'    => 'POST',
+			'headers'   => [
+				'Content-Type'  => 'application/json',
+				'Authorization' => 'Bearer ' . $access_token,
+			],
+			'body'      => json_encode( [ 'id' => $paypal_order_id ] ),
+		];
+
+        $response = wp_remote_post( $capture_url, $args );
+		$http_code = wp_remote_retrieve_response_code( $response );
+		$body = wp_remote_retrieve_body( $response );
+		$response_data = json_decode( $body, true );
+		error_log( '(Proxy) PayPal capture payment response: ' . print_r( $response_data, true ) );
+
+		if ( in_array( $http_code, [ 200, 201 ], true ) ) {
+			return new WP_REST_Response(
+				$response_data,
+				200
+			);
+		} else {
+			error_log( '(Proxy) Failed to capture PayPal order. ' . print_r( $response_data, true ) );
+			return new WP_REST_Response(
+				$response_data,
+				500
+			);
+		}
+    }
+
+    private function get_paypal_access_token() {
+		$paypal_client_id = get_option( 'wc_paypal_api_client_id' );
+		$paypal_client_secret = get_option( 'wc_paypal_api_client_secret' );
+
+		if ( ! $paypal_client_id || ! $paypal_client_secret ) {
+			error_log( '(Proxy) PayPal client ID or secret not found. Cannot get access token.' );
+			return null;
+		}
+
+		$args = [
+			'method'    => 'POST',
+			'headers'   => [
+				'Content-Type'  => 'application/x-www-form-urlencoded',
+				'Authorization' => 'Basic ' . base64_encode( $paypal_client_id . ':' . $paypal_client_secret ),
+			],
+			'body'      => 'grant_type=client_credentials',
+			'timeout'   => 45, // TODO
+			'sslverify' => false, // TODO
+		];
+		error_log( '(Proxy) PayPal access token request: ' . print_r( $args, true ) );
+
+		$response = wp_remote_post( 'https://api-m.sandbox.paypal.com/v1/oauth2/token', $args);
+		$http_code = wp_remote_retrieve_response_code( $response );
+    	$body = wp_remote_retrieve_body( $response );
+    	$data = json_decode( $body, true );
+
+    	// Check if the request was successful (HTTP 200 OK) and access token exists
+		if ( $http_code === 200 && isset( $data['access_token'] ) ) {
+			error_log( '(Proxy) PayPal access token request successful.' );
+			return $data['access_token'];
+		} else {
+			error_log( '(Proxy) Failed to get PayPal access token. ' . print_r( $data, true ) );
+			return null;
+		}
+	}
+}
+
+new WC_Gateway_Paypal_Proxy();


### PR DESCRIPTION
Spike work on moving the gateway to use Orders v2.

This simple PoC implements end-to-end payment capture, and uses a simple proxy layer.

Add this snippet:
```
add_action( 'init', function() {
  // Set migration flag
  $paypal_settings = get_option( 'woocommerce_paypal_settings', array() );  
  $paypal_settings['use_orders_v2'] = 'yes';
  update_option( 'woocommerce_paypal_settings', $paypal_settings );
  
  // Set client ID and secret, and payee account email
  update_option( 'wc_paypal_api_client_id', '<your client ID>' );
  update_option( 'wc_paypal_api_client_secret', '<your client secret>' );
  update_option( 'wc_paypal_api_payee_email', '<account email of payee>' );
} );
```